### PR TITLE
Ability to pass additional options to L.StamenTileLayer

### DIFF
--- a/js/tile.stamen.js
+++ b/js/tile.stamen.js
@@ -127,18 +127,19 @@ if (typeof MM === "object") {
  */
 if (typeof L === "object") {
     L.StamenTileLayer = L.TileLayer.extend({
-        initialize: function(name) {
+        initialize: function(name, options) {
             var provider = getProvider(name),
                 url = provider.url.replace(/({[A-Z]})/g, function(s) {
                     return s.toLowerCase();
+                }),
+                opts = L.extend({}, options, {
+                    "minZoom":      provider.minZoom,
+                    "maxZoom":      provider.maxZoom,
+                    "subdomains":   provider.subdomains,
+                    "scheme":       "xyz",
+                    "attribution":  provider.attribution
                 });
-            L.TileLayer.prototype.initialize.call(this, url, {
-                "minZoom":      provider.minZoom,
-                "maxZoom":      provider.maxZoom,
-                "subdomains":   provider.subdomains,
-                "scheme":       "xyz",
-                "attribution":  provider.attribution
-            });
+            L.TileLayer.prototype.initialize.call(this, url, opts);
         }
     });
 }

--- a/test/leaflet.html
+++ b/test/leaflet.html
@@ -16,7 +16,9 @@
                         center: new L.LatLng(37.8, -122.4),
                         zoom: 10
                     });
-                    map.addLayer(new L.StamenTileLayer(layer));
+                    map.addLayer(new L.StamenTileLayer(layer, {
+                        detectRetina: true
+                    }));
                 }
             }
         </script>


### PR DESCRIPTION
The `L.TileLayer` constructor takes an `options` object as a second argument, which `L.StamenTileLayer` ignores. I've patched it so that:
- the user can send an `options` object to StamenTileLayer's superclass;
- options like `minZoom` and `maxZoom` are still overwritten by StamenTileLayer to ensure we don't get outside acceptable bounds.

There are at least two useful options one can now use:
- `detectRetina: true` makes Stamen Maps look nice and crisp on high-DPI displays;
- `opacity: [0-1]` to control layer opacity.

Et cetera.
