### PR TITLE
Factory function added for consistency with Leaflet conventions

### DIFF
--- a/js/tile.stamen.js
+++ b/js/tile.stamen.js
@@ -141,6 +141,13 @@ if (typeof L === "object") {
             });
         }
     });
+
+    /*
+     * Factory function for consistency with Leaflet conventions 
+     */
+    L.stamenTileLayer = function (options, source) {
+        return new L.StamenTileLayer(options, source);
+    };
 }
 
 /*


### PR DESCRIPTION
Leaflet defines factory functions for classes for convenience (named after class constructors except for lowercase initial). Code sample for use of Stamen tiles with Leaflet becomes:

// replace "toner" here with "terrain" or "watercolor"
  var layer = L.stamenTileLayer("toner");
  var map = L.map("element_id", {
    center: L.latLng(37.7, -122.4),
    zoom: 12
  });
  map.addLayer(layer);
