### PR TITLE
Change SUBDOMAINS spec string so that it works on Stamen's SSL Fastly

### DIFF
--- a/js/tile.stamen.js
+++ b/js/tile.stamen.js
@@ -4,7 +4,7 @@
  * tile.stamen.js v1.2.4
  */
 
-var SUBDOMAINS = " a. b. c. d.".split(" "),
+var SUBDOMAINS = "a. b. c. d.".split(" "),
     MAKE_PROVIDER = function(layer, type, minZoom, maxZoom) {
         return {
             "url":          ["http://{S}tile.stamen.com/", layer, "/{Z}/{X}/{Y}.", type].join(""),


### PR DESCRIPTION
I also found that the instructions given at http://maps.stamen.com/#usage-ssl for multiple subdomains over SSL have the wrong URL specification. It says to use https://stamen-tiles-{S}.a.ssl.fastly.net but https://stamen-tiles-{S}a.ssl.fastly.net is the correct spec.
