### PR TITLE
Fixed attribution error for OpenLayers Maps

### DIFF
--- a/js/tile.stamen.js
+++ b/js/tile.stamen.js
@@ -188,7 +188,7 @@ if (typeof OpenLayers === "object") {
                 "tileOptions": {
                     "crossOriginKeyword": null
                 },
-                "attribution": ATTRIBUTION
+                "attribution": provider.attribution
             }, options);
             return OpenLayers.Layer.OSM.prototype.initialize.call(this, name, hosts, options);
         }


### PR DESCRIPTION
When using the maps with OpenLayers an error "ATTRIBUTION is not defined" is raised. This pull request fixes the bug.
