### PR TITLE
Allow HTTP or HTTPS access of tiles through file

### DIFF
--- a/js/tile.stamen.js
+++ b/js/tile.stamen.js
@@ -7,7 +7,7 @@
 var SUBDOMAINS = "a. b. c. d.".split(" "),
     MAKE_PROVIDER = function(layer, type, minZoom, maxZoom) {
         return {
-            "url":          ["http://{S}tile.stamen.com/", layer, "/{Z}/{X}/{Y}.", type].join(""),
+            "url":          ["//stamen-tiles-{S}a.ssl.fastly.net/", layer, "/{Z}/{X}/{Y}.", type].join(""),
             "type":         type,
             "subdomains":   SUBDOMAINS.slice(),
             "minZoom":      minZoom,


### PR DESCRIPTION
Allow a website to pull in Stamen tiles through HTTP or HTTPS protocol.