### PR TITLE
Change "donate" to "hire us!" everywhere

### DIFF
--- a/donate-to-hire.sh
+++ b/donate-to-hire.sh
@@ -1,0 +1,12 @@
+# This script was used to replace all instances of the "donate" link with a "hire us!" link.
+# -- Curran May 2021
+
+# Inspired by https://superuser.com/questions/428493/how-can-i-do-a-recursive-find-and-replace-from-the-command-line
+
+# Change the tooltip and href
+find . -type f -name '*.html' -print0 | xargs -0 sed -i'' -e 's/title="donate" href="https:\/\/stamen.com\/opensource\/#donate"/title="hire us!" href="https:\/\/stamen.com\/contact\/"/'
+
+# Change the visible content
+find . -type f -name '*.html' -print0 | xargs -0 sed -i'' -e 's/>donate</>hire us!</g'
+
+

--- a/terrain-background/index.html
+++ b/terrain-background/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/terrain-labels/index.html
+++ b/terrain-labels/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/terrain-lines/index.html
+++ b/terrain-lines/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/terrain/beta/index.html
+++ b/terrain/beta/index.html
@@ -54,7 +54,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/terrain/index.html
+++ b/terrain/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/toner-2010/index.html
+++ b/toner-2010/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/toner-2011/index.html
+++ b/toner-2011/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/toner-background/index.html
+++ b/toner-background/index.html
@@ -54,7 +54,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/toner-hybrid/index.html
+++ b/toner-hybrid/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/toner-labels/index.html
+++ b/toner-labels/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/toner-lines/index.html
+++ b/toner-lines/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/toner-lite/index.html
+++ b/toner-lite/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/toner/index.html
+++ b/toner/index.html
@@ -55,7 +55,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/trees-cabs-crime/index.html
+++ b/trees-cabs-crime/index.html
@@ -52,7 +52,7 @@
             <div id="embed" class="toggle controls">
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <!-- <a id="make-image" title="make an image of this map">&lt;image&gt;</a> -->
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>
                     <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>

--- a/watercolor/index.html
+++ b/watercolor/index.html
@@ -56,7 +56,7 @@
 
                 <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                <a id="donate-link" title="donate" href="https://stamen.com/opensource/#donate" target="_blank">donate</a>
+                <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <a id="buy-toggle" class="" title="Buy a print from Mapisart" href="http://mapisart.com" target="_blank">&lt;buy&gt;</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">
                     <p>Copy the HTML below to embed this map:</p>


### PR DESCRIPTION
This PR changes "donate" to "hire us!" on all pages where the donate button exists.

A bash script, [donate-to-hire.sh](https://github.com/stamen/maps.stamen.com/pull/178/files#diff-8b90a4e0c8ae82b5731bbba991021d0040c47b308547bbaad27b408757bf429c), was used to do this automatically.