### PR TITLE
Remove embed buttons

### DIFF
--- a/css/layer.css
+++ b/css/layer.css
@@ -61,14 +61,6 @@ body {
     right: 20px;
 }
 
-#embed-content {
-    clear: both;
-    width: 320px;
-    color: #fff !important;
-    background: #000;
-    padding: 10px;
-}
-
 #feedback {
     top: -20px;
 }

--- a/css/screen.css
+++ b/css/screen.css
@@ -448,14 +448,6 @@ a#toggle-feedback.active {
     display: none;
 }
 
-#embed-content {
-    clear: both;
-    width: 320px;
-    color: #fff !important;
-    background: #000;
-    padding: 10px;
-}
-
 #embed.controls a {
     float: right;
 }

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
                 </form>
 
                 <div id="embed" class="toggle controls">
-                    <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                    
                     <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                     <div id="embed-content" class="toggle-content" style="display: none;">
                         <p>Copy the HTML below to embed this map:</p>

--- a/index.html
+++ b/index.html
@@ -67,12 +67,7 @@
                 </form>
 
                 <div id="embed" class="toggle controls">
-                    
                     <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
-                    <div id="embed-content" class="toggle-content" style="display: none;">
-                        <p>Copy the HTML below to embed this map:</p>
-                        <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                    </div>
                 </div>
 
                 <div id="controls" class="controls">

--- a/js/index.js
+++ b/js/index.js
@@ -205,24 +205,6 @@ var MAPS = {};
         var embedAndImage = function(){
             var __ = {};
 
-            var embedLink = document.getElementById("embed-toggle"),
-                embedToggle;
-            if (embedLink) {
-                var embed = document.getElementById("embed-content"),
-                    textarea = document.getElementById("embed-code"),
-                    template = textarea.value;
-                embedToggle = createToggle(embedLink, embed, function(showing) {
-                    if (showing) {
-                        var url = location.href.split("#");
-                        url.splice(1, 0, "embed#");
-                        textarea.value = template.replace("{url}", url.join(""));
-                        textarea.focus();
-                        textarea.select();
-                    } else {
-                    }
-                });
-            }
-
             var imgLink = document.getElementById("make-image");
             if (imgLink) {
                 var round = function(n) {

--- a/js/layer.js
+++ b/js/layer.js
@@ -74,24 +74,6 @@
             parts.unshift(providerName);
         });
 
-        var embedLink = document.getElementById("embed-toggle"),
-            embedToggle;
-        if (embedLink) {
-            var embed = document.getElementById("embed-content"),
-                textarea = document.getElementById("embed-code"),
-                template = textarea.value;
-            embedToggle = createToggle(embedLink, embed, function(showing) {
-                if (showing) {
-                    var url = location.href.split("#");
-                    url.splice(1, 0, "embed#");
-                    textarea.value = template.replace("{url}", url.join(""));
-                    textarea.focus();
-                    textarea.select();
-                } else {
-                }
-            });
-        }
-
         var imgLink = document.getElementById("make-image");
         if (imgLink) {
             var round = function(n) {

--- a/remove-embeds.sh
+++ b/remove-embeds.sh
@@ -9,5 +9,4 @@
 # Remove embed code toggler.
 find . -type f -name '*.html' -print0 | xargs -0 sed -i'' -e 's/<a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;<\/a>//g'
 
-# Remove embed code content
-#find . -type f -name '*.html' -print0 | xargs -0 sed -i'' -e 's/<div id="embed-content"//g'
+# embed-content removed manually

--- a/remove-embeds.sh
+++ b/remove-embeds.sh
@@ -1,0 +1,13 @@
+# This script was used to remove the "embed" button across pages.
+# -- Curran May 2021
+
+# Inspired by https://superuser.com/questions/428493/how-can-i-do-a-recursive-find-and-replace-from-the-command-line
+
+# Original string:
+
+
+# Remove embed code toggler.
+find . -type f -name '*.html' -print0 | xargs -0 sed -i'' -e 's/<a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;<\/a>//g'
+
+# Remove embed code content
+#find . -type f -name '*.html' -print0 | xargs -0 sed -i'' -e 's/<div id="embed-content"//g'

--- a/terrain-background/index.html
+++ b/terrain-background/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/terrain-background/index.html
+++ b/terrain-background/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/terrain-labels/index.html
+++ b/terrain-labels/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/terrain-labels/index.html
+++ b/terrain-labels/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/terrain-lines/index.html
+++ b/terrain-lines/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/terrain-lines/index.html
+++ b/terrain-lines/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/terrain/beta/index.html
+++ b/terrain/beta/index.html
@@ -52,7 +52,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/terrain/beta/index.html
+++ b/terrain/beta/index.html
@@ -52,13 +52,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
         </div>
 

--- a/terrain/index.html
+++ b/terrain/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/terrain/index.html
+++ b/terrain/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/toner-2010/index.html
+++ b/toner-2010/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/toner-2010/index.html
+++ b/toner-2010/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/toner-2011/index.html
+++ b/toner-2011/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/toner-2011/index.html
+++ b/toner-2011/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/toner-background/index.html
+++ b/toner-background/index.html
@@ -52,7 +52,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/toner-background/index.html
+++ b/toner-background/index.html
@@ -52,13 +52,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/toner-hybrid/index.html
+++ b/toner-hybrid/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/toner-hybrid/index.html
+++ b/toner-hybrid/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/toner-labels/index.html
+++ b/toner-labels/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/toner-labels/index.html
+++ b/toner-labels/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/toner-lines/index.html
+++ b/toner-lines/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/toner-lines/index.html
+++ b/toner-lines/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/toner-lite/index.html
+++ b/toner-lite/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/toner-lite/index.html
+++ b/toner-lite/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/toner/index.html
+++ b/toner/index.html
@@ -53,13 +53,8 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/toner/index.html
+++ b/toner/index.html
@@ -53,7 +53,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/trees-cabs-crime/index.html
+++ b/trees-cabs-crime/index.html
@@ -50,13 +50,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                
-                <!-- <a id="make-image" title="make an image of this map">&lt;image&gt;</a> -->
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/trees-cabs-crime/index.html
+++ b/trees-cabs-crime/index.html
@@ -50,7 +50,7 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <!-- <a id="make-image" title="make an image of this map">&lt;image&gt;</a> -->
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <div id="embed-content" class="toggle-content" style="display: none;">

--- a/watercolor/index.html
+++ b/watercolor/index.html
@@ -53,15 +53,9 @@
                 </a>
             </div>
             <div id="embed" class="toggle controls">
-
-                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <a id="buy-toggle" class="" title="Buy a print from Mapisart" href="http://mapisart.com" target="_blank">&lt;buy&gt;</a>
-                <div id="embed-content" class="toggle-content" style="display: none;">
-                    <p>Copy the HTML below to embed this map:</p>
-                    <textarea id="embed-code" rows="3">&lt;iframe width="600" height="420" src="{url}"&gt;&lt;/iframe&gt;</textarea>
-                </div>
             </div>
             <div id="feedback" class="toggle" style="display: none;">
                 <div>

--- a/watercolor/index.html
+++ b/watercolor/index.html
@@ -54,7 +54,7 @@
             </div>
             <div id="embed" class="toggle controls">
 
-                <a id="embed-toggle" class="toggler" title="embed this map">&lt;embed&gt;</a>
+                
                 <a id="make-image" title="make an image of this map">&lt;image&gt;</a>
                 <a id="donate-link" title="hire us!" href="https://stamen.com/contact/" target="_blank">hire us!</a>
                 <a id="buy-toggle" class="" title="Buy a print from Mapisart" href="http://mapisart.com" target="_blank">&lt;buy&gt;</a>


### PR DESCRIPTION
Remove all embed toggle buttons from HTML via script.

This feels a bit better than #180, but it's still not totally thorough as the `#embed-content` blocks are still present.

I tried to get rid of those too, but could not get it to work with sed.

Tried many variations of the following (it turns out sed and newlines are not friends):

```
# Remove embed code content
find . -type f -name '*.html' -print0 | xargs -0 sed -i'' -e ':a;N;$!ba;s/<div id="embed-content"\(.*|\)div>//g'
```