### PR TITLE
switch "make image" link to use Stadia's build-a-map instead of m2i

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -225,15 +225,11 @@ var MAPS = {};
                     return Math.ceil(n / 500) * 500;
                 };
                 imgLink.addEventListener("mouseover", function() {
-                    var size = main.getSize();
-                    var hash = location.hash.substr(1),
-                        width = round(size.x),
-                        height = round(size.y);
+                    var hash = location.hash.substr(1);
                     this.href = [
-                        "http://maps.stamen.com/m2i/",
-                        "#" + currentProvider, "/",
-                        width, ":", height, "/",
-                        hash
+                        "https://stadiamaps.com/build-a-map/",
+                        "#style=stamen_" + currentProvider.replaceAll("-", "_"),
+                        "&map=" + hash
                     ].join("");
                 });
             };

--- a/js/layer.js
+++ b/js/layer.js
@@ -80,15 +80,11 @@
                 return Math.ceil(n / 500) * 500;
             };
             imgLink.addEventListener("mouseover", function() {
-                var size = main.getSize();
-                var hash = location.hash.substr(1),
-                    width = round(size.x),
-                    height = round(size.y);
+                var hash = location.hash.substr(1);
                 this.href = [
-                    "http://maps.stamen.com/m2i/",
-                    "#" + providerName, "/",
-                    width, ":", height, "/",
-                    hash
+                    "https://stadiamaps.com/build-a-map/",
+                    "#style=stamen_" + providerName.replaceAll("-", "_"),
+                    "&map=" + hash
                 ].join("");
             });
         }


### PR DESCRIPTION
Now that Stadia enabled passing the map style name in to their build-a-map tool, we can stop linking to [our m2i page](https://maps.stamen.com/m2i/#toner/) (which currently has a big banner saying it doens't work and telling them to go to Stadia's tool) and link directly to Stadia.

The exact map extent isn't passed, but the zoom and center coords are passed correctly, and that's probably good enough.